### PR TITLE
chore(tslint): add valor-software ts-lint configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "stylus-loader": "1.5.1",
     "to-string-loader": "1.1.3",
     "ts-loader": "0.8.1",
-    "tslint": "3.7.0",
+    "tslint-config-valorsoft": "0.0.2",
     "typescript": "1.8.9",
     "typings": "0.7.12",
     "webpack": "1.12.14"


### PR DESCRIPTION
Configuration doesn't work in Webstorm for now - package tslint-config-valorsoft should be fixed probably
